### PR TITLE
 This fixes the size of the score array which will later be interpolated to create the final saliency map.

### DIFF
--- a/saliency.py
+++ b/saliency.py
@@ -41,7 +41,7 @@ def score_frame(model, history, ix, r, d, interp_func, mode='actor'):
     #    if d==2 then every other, which is 25% of total pixels for a 2D image)
     assert mode in ['actor', 'critic'], 'mode must be either "actor" or "critic"'
     L = run_through_model(model, history, ix, interp_func, mask=None, mode=mode)
-    scores = np.zeros((int(80/d)+1,int(80/d)+1)) # saliency scores S(t,i,j)
+    scores = np.zeros((int(79/d)+1,int(79/d)+1)) # saliency scores S(t,i,j)
     for i in range(0,80,d):
         for j in range(0,80,d):
             mask = get_mask(center=[i,j], size=[80,80], r=r)


### PR DESCRIPTION
The original calculation of the size of the scores array used *"int(80/d)+1"*.
This works correctly for d with 80 % d != 0.
However, if 80 % d = 0, this creates an additional row and column which will never be reached by the loop *"for i in range(0,80,d)"*.
For example, if the d=1, then the scores array would have size 81x81 instead of the intended 80x80(one value for each pixel).
d=5 hast the same problem, such that the last row and column are never reached by the loop and will always be 0.
When the saliency map is resized to 80x80 later, this results in saliency maps that are shifted to the top left and never have meaningful values in the last rows and columns.

I propose to use *"int(79/d)+1"* for the size of the scores array instead. 
This keeps the functionality for d with 80 % d != 0 which just removing the *+1* and using *"int(80/d)"* would not do.
In addition, *"int(79/d)+1"* results in exactly one less column and row for d with  80 % d = 0.
For example for d=1, *"int(79/d)+1"* correctly results in a scores array of size 80x80.
